### PR TITLE
Fix issue #10 to avoid panics with invalid JSON

### DIFF
--- a/request.go
+++ b/request.go
@@ -65,7 +65,13 @@ func UnmarshalPayload(in io.Reader, model interface{}) error {
 
 }
 
-func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) error {
+func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("data is not a jsonapi representation of '%v'", model.Type())
+		}
+	}()
+
 	modelValue := model.Elem()
 	modelType := model.Type().Elem()
 

--- a/request_test.go
+++ b/request_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -24,6 +25,17 @@ func TestMalformedTag(t *testing.T) {
 
 	if !r.Match([]byte(err.Error())) {
 		t.Fatalf("The err was not due two two few arguments in a tag")
+	}
+}
+
+func TestUnmarshalInvalidJSON(t *testing.T) {
+	in := strings.NewReader("{}")
+	out := new(Blog)
+
+	err := UnmarshalPayload(in, out)
+
+	if err == nil {
+		t.Fatalf("Did not error out the invalid JSON.")
 	}
 }
 


### PR DESCRIPTION
This fixes the panic happening when trying to unmarshal JSON that’s not in a JSON API format.